### PR TITLE
docs: remove ideal-brainstorm skill reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 │
 ├── .claude/                       # Claude Code 相关
 │   ├── skills/                    # 定制化 skills（项目级）
-│   │   ├── ideal-brainstorm/      # 头脑风暴（通用）
 │   │   ├── ideal-requirement/     # 需求编写（通用）
 │   │   ├── ideal-dev-solution/    # 技术方案（开发领域）
 │   │   ├── ideal-dev-plan/        # 计划生成（开发领域）


### PR DESCRIPTION
移除 README.md 中的 ideal-brainstorm skill 条目，统一使用 ideal-requirement skill 进行需求编写。